### PR TITLE
Update web socket endpoint & minor changes to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ sudo ./deploy.sh
 sudo pip3 install rosdep rosinstall_generator wstool rosinstall
 sudo pip3 install autobahn
 cd <catkin_ws_root>
-catkin_make_isolated --pkg blockly --install
+catkin_make_isolated --pkg robot_blockly --install
 source install_isolated/setup.bash
-rosrun robot_blockly blockly_backend.py
+rosrun robot_blockly robot_blockly_backend.py
 
 # now go to http://erle-brain-2.local/
 #  and start playing!

--- a/frontend/pages/blockly.html
+++ b/frontend/pages/blockly.html
@@ -532,7 +532,8 @@
 
   // window.onload = function() {
   function launchwebsockets() {
-    socket = new WebSocket("ws://0.0.0.0:9000");
+    var hostName = window.location.hostname;
+    socket = new WebSocket("ws://" + hostName + ":9000");
     // socket = new WebSocket("ws://127.0.0.1:9000");
     // socket = new WebSocket("ws://10.0.0.1:9000");
     // socket = new WebSocket("ws:/erle-brain-2.local:9000");


### PR DESCRIPTION
The script is executed in the browser, so when the address is localhost or 0.0.0.0 it means 'browser's computer'.
This is not what is expected in most cases.  The address should be 'the same computer where the robot_blocky frontend is running'.