### PR TITLE
adding missing dependency rospy

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,8 +19,10 @@
 
   <build_depend>std_msgs</build_depend> 
   <build_depend>message_generation</build_depend>
+  <build_depend>rospy</build_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>rospy</run_depend>
   <buildtool_depend>catkin</buildtool_depend>  
   <buildtool_depend>message_runtime</buildtool_depend>
 


### PR DESCRIPTION
When trying to run this on our build farm I noticed the missing `rospy` dependency. Small fix, but important if ever planned to be released properly. There may be other dependencies missing.